### PR TITLE
Add Gradle 9.0 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.6.1'
     }
 }
 
@@ -34,9 +34,10 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
-
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip


### PR DESCRIPTION
As of the current stable Flutter (3.35, released Aug 2025), Google’s release post states you must have at least Gradle 8.7.0, AGP 8.6.0, and Java 17:

https://medium.com/flutter/whats-new-in-flutter-3-35-c58ef72e3766

This PR updates the Gradle configuration to minimal requirements and makes it compatible with Gradle 9.0